### PR TITLE
Unify interfaces

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -6,6 +6,20 @@ This is a record of all past noggin releases and what went into them,
 in reverse chronological order. All previous releases should still be available
 on pip.
 
+.. _v0.10.0:
+
+-------------------
+0.10.0 - 2019-06-15
+-------------------
+
+Normalizes the interfaces of :class:`~noggin.logger.LiveLogger` and :class:`~noggin.plotter.LivePlot`
+so that they can be used as drop-in replacements for each other more seamlessly.
+
+This is an API-breaking update for :class:`~noggin.plotter.LivePlot`, as it renames the methods
+``plot_train_epoch`` and ``plot_test_epoch`` to ``set_train_epoch`` and ``set_test_epoch``,
+respectively. As stated above, this is to match the interface of  :class:`~noggin.logger.LiveLogger`.
+
+
 .. _v0.9.1:
 
 -------------------

--- a/docs/source/generated/noggin.plotter.LivePlot.plot_test_epoch.rst
+++ b/docs/source/generated/noggin.plotter.LivePlot.plot_test_epoch.rst
@@ -1,6 +1,0 @@
-noggin.plotter.LivePlot.plot\_test\_epoch
-=========================================
-
-.. currentmodule:: noggin.plotter
-
-.. automethod:: LivePlot.plot_test_epoch

--- a/docs/source/generated/noggin.plotter.LivePlot.plot_train_epoch.rst
+++ b/docs/source/generated/noggin.plotter.LivePlot.plot_train_epoch.rst
@@ -1,6 +1,0 @@
-noggin.plotter.LivePlot.plot\_train\_epoch
-==========================================
-
-.. currentmodule:: noggin.plotter
-
-.. automethod:: LivePlot.plot_train_epoch

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -34,12 +34,12 @@ record and plot data during an experiment.
         if i%10 == 0 and i > 0:
             plotter.plot_train_epoch()
 
-           # cue test-evaluation of model
-           for x in np.linspace(0, 10, 5):
-               x += (np.random.rand(1) - 0.5)*5
-               test_metrics = {"accuracy": x**2}
-               plotter.set_test_batch(test_metrics, batch_size=1)
-           plotter.plot_test_epoch()
+            # cue test-evaluation of model
+            for x in np.linspace(0, 10, 5):
+                x += (np.random.rand(1) - 0.5)*5
+                test_metrics = {"accuracy": x**2}
+                plotter.set_test_batch(test_metrics, batch_size=1)
+            plotter.set_test_epoch()
     plotter.plot()  # ensures final data gets plotted
 
 .. image:: _static/liveplot.gif

--- a/docs/source/workflow.rst
+++ b/docs/source/workflow.rst
@@ -80,8 +80,8 @@ We will be passing batches of training data to our model-training function, reco
                 _, test_accuracy = training_loop(batch)
                 plotter.set_test_batch(dict(accuracy=test_accuracy),
                                        batch_size=len(batch))
-            plotter.plot_train_epoch()
-            plotter.plot_test_epoch()
+            plotter.set_train_epoch()
+            plotter.set_test_epoch()
     # make sure any "straggler" data gets plotted
     plotter.plot()
 

--- a/src/noggin/logger.py
+++ b/src/noggin/logger.py
@@ -474,9 +474,7 @@ class LiveLogger:
 
         return msg
 
-    def set_train_batch(
-        self, metrics: Dict[str, Real], batch_size: Integral, **kwargs
-    ):  # lgtm [py/inheritance/incorrect-overridden-signature]
+    def set_train_batch(self, metrics: Dict[str, Real], batch_size: Integral, **kwargs):
         """Record batch-level measurements for train-metrics.
 
         Parameters
@@ -509,17 +507,11 @@ class LiveLogger:
 
         self._num_train_batch += 1
 
-    def set_train_epoch(self, **kwargs):
+    def set_train_epoch(self):
         """Record an epoch for the train-metrics.
 
         Computes epoch-level statistics based on the batches accumulated since
         the prior epoch.
-
-        Notes
-        -----
-        ``**kwargs`` is included in the signature only to facilitate a seamless
-        drop-in replacement for :obj:`~noggin.plotter.LivePlot`. It is not
-        utilized here.
         """
         # compute epoch-mean metrics
         for key in self._train_metrics:
@@ -558,17 +550,11 @@ class LiveLogger:
 
         self._num_test_batch += 1
 
-    def set_test_epoch(self, **kwargs):
+    def set_test_epoch(self):
         """Record an epoch for the test-metrics.
 
         Computes epoch-level statistics based on the batches accumulated since
         the prior epoch.
-
-        Notes
-        -----
-        ``**kwargs`` is included in the signature only to facilitate a seamless
-        drop-in replacement for :obj:`~noggin.plotter.LivePlot`. It is not
-        utilized here.
         """
         # compute epoch-mean metrics
         for key in self._test_metrics:

--- a/src/noggin/logger.py
+++ b/src/noggin/logger.py
@@ -438,7 +438,11 @@ class LiveLogger:
             setattr(new, "_" + item, logger_dict[item])
         return new
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        """LiveLogger.__init__ does not utilize any input arguments, but accepts
+        ``*args, **kwargs`` so that it can be used as a drop-in replacement for
+         :obj:`~noggin.plotter.LivePlot`.
+        """
         self._num_train_epoch = 0  # int: Current number of epochs trained
         self._num_train_batch = 0  # int: Current number of batches trained
         self._num_test_epoch = 0  # int: Current number of epochs tested
@@ -471,7 +475,7 @@ class LiveLogger:
         return msg
 
     def set_train_batch(
-        self, metrics: Dict[str, Real], batch_size: Integral
+        self, metrics: Dict[str, Real], batch_size: Integral, **kwargs
     ):  # lgtm [py/inheritance/incorrect-overridden-signature]
         """Record batch-level measurements for train-metrics.
 
@@ -483,7 +487,14 @@ class LiveLogger:
 
         batch_size : Integral
             The number of samples in the batch used to produce the metrics.
-            Used to weight the metrics to produce epoch-level statistics. """
+            Used to weight the metrics to produce epoch-level statistics.
+
+        Notes
+        -----
+        ``**kwargs`` is included in the signature only to facilitate a seamless
+        drop-in replacement for :obj:`~noggin.plotter.LivePlot`. It is not
+        utilized here.
+        """
 
         if not self._num_train_batch:
             # initialize batch-level metrics
@@ -498,11 +509,17 @@ class LiveLogger:
 
         self._num_train_batch += 1
 
-    def set_train_epoch(self):
+    def set_train_epoch(self, **kwargs):
         """Record an epoch for the train-metrics.
 
         Computes epoch-level statistics based on the batches accumulated since
         the prior epoch.
+
+        Notes
+        -----
+        ``**kwargs`` is included in the signature only to facilitate a seamless
+        drop-in replacement for :obj:`~noggin.plotter.LivePlot`. It is not
+        utilized here.
         """
         # compute epoch-mean metrics
         for key in self._train_metrics:
@@ -510,7 +527,7 @@ class LiveLogger:
 
         self._num_train_epoch += 1
 
-    def set_test_batch(self, metrics: Dict[str, Real], batch_size: Integral):
+    def set_test_batch(self, metrics: Dict[str, Real], batch_size: Integral, **kwargs):
         """Record batch-level measurements for test-metrics.
 
         Parameters
@@ -522,7 +539,13 @@ class LiveLogger:
         batch_size : Integral
             The number of samples in the batch used to produce the metrics.
             Used to weight the metrics to produce epoch-level statistics.
-            """
+
+        Notes
+        -----
+        ``**kwargs`` is included in the signature only to facilitate a seamless
+        drop-in replacement for :obj:`~noggin.plotter.LivePlot`. It is not
+        utilized here.
+        """
         if not self._num_test_batch:
             self._test_metrics.update((key, LiveMetric(key)) for key in metrics)
 
@@ -535,11 +558,17 @@ class LiveLogger:
 
         self._num_test_batch += 1
 
-    def set_test_epoch(self):
+    def set_test_epoch(self, **kwargs):
         """Record an epoch for the test-metrics.
 
         Computes epoch-level statistics based on the batches accumulated since
         the prior epoch.
+
+        Notes
+        -----
+        ``**kwargs`` is included in the signature only to facilitate a seamless
+        drop-in replacement for :obj:`~noggin.plotter.LivePlot`. It is not
+        utilized here.
         """
         # compute epoch-mean metrics
         for key in self._test_metrics:

--- a/src/noggin/plotter.py
+++ b/src/noggin/plotter.py
@@ -494,7 +494,7 @@ class LivePlot(LiveLogger):
         if self._plot_batch:
             self._do_liveplot()
 
-    def plot_train_epoch(self):
+    def set_train_epoch(self):
         """Record and plot an epoch for the train-metrics.
 
         Computes epoch-level statistics based on the batches accumulated since
@@ -519,7 +519,7 @@ class LivePlot(LiveLogger):
             self._filter_unregistered_metrics(metrics), batch_size=batch_size
         )
 
-    def plot_test_epoch(self):
+    def set_test_epoch(self):
         """Record and plot an epoch for the test-metrics.
 
         Computes epoch-level statistics based on the batches accumulated since
@@ -720,11 +720,3 @@ class LivePlot(LiveLogger):
         """ Calls ``matplotlib.pyplot.show()``. For visualizing a static-plot"""
         if not self._liveplot:
             self._pyplot.show()
-
-    def set_test_epoch(self):
-        """ Not implemented. Use `plot_test_epoch` instead"""
-        raise NotImplementedError("Use the method `plot_test_epoch` instead")
-
-    def set_train_epoch(self):
-        """ Not implemented. Use `plot_train_epoch` instead"""
-        raise NotImplementedError("Use the method `plot_train_epoch` instead")

--- a/tests/base_state_machines.py
+++ b/tests/base_state_machines.py
@@ -94,7 +94,7 @@ class LivePlotStateMachine(RuleBasedStateMachine):
     @rule()
     def set_train_epoch(self):
         self.logger.set_train_epoch()
-        self.plotter.plot_train_epoch()
+        self.plotter.set_train_epoch()
 
     @rule(batch_size=st.integers(0, 2), data=st.data())
     def set_test_batch(self, batch_size: int, data: SearchStrategy):
@@ -110,7 +110,7 @@ class LivePlotStateMachine(RuleBasedStateMachine):
     @rule()
     def set_test_epoch(self):
         self.logger.set_test_epoch()
-        self.plotter.plot_test_epoch()
+        self.plotter.set_test_epoch()
 
     def teardown(self):
         plt.close("all")

--- a/tests/test_LiveLogger.py
+++ b/tests/test_LiveLogger.py
@@ -53,6 +53,14 @@ def test_fuzz_set_epoch(logger: LiveLogger):
     logger.set_test_epoch()
 
 
+@pytest.mark.parametrize(
+    ("args", "kwargs"),
+    [(tuple(), dict()), ((["metric_a", "metric_b"], 0.5), dict(nrows=2))],
+)
+def test_logger_init_compatible_with_plotter(args: tuple, kwargs: dict):
+    LiveLogger(*args, **kwargs)
+
+
 class LiveLoggerStateMachine(RuleBasedStateMachine):
     """ Ensures that exercising the api of LiveLogger produces
     results that are consistent with a simplistic implementation"""

--- a/tests/test_LivePlot.py
+++ b/tests/test_LivePlot.py
@@ -113,21 +113,12 @@ def test_unregister_metric_warns():
         plotter.set_test_batch(dict(a=1, c=1), batch_size=1)
 
 
-@given(plotter=cst.plotters())
-def test_residual_logger_methods_raise(plotter: LivePlot):
-    with pytest.raises(NotImplementedError):
-        plotter.set_train_epoch()
-
-    with pytest.raises(NotImplementedError):
-        plotter.set_test_epoch()
-
-
 def test_trivial_case():
     """ Perform a trivial sanity check on live plotter"""
     plotter = LivePlot("a")
     plotter.set_train_batch(dict(a=1.0), batch_size=1, plot=False)
     plotter.set_train_batch(dict(a=3.0), batch_size=1, plot=False)
-    plotter.plot_train_epoch()
+    plotter.set_train_epoch()
 
     assert_array_equal(plotter.train_metrics["a"]["batch_data"], np.array([1.0, 3.0]))
     assert_array_equal(plotter.train_metrics["a"]["epoch_domain"], np.array([2]))

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -149,8 +149,8 @@ def test_plot_batches_flag_via_set_batch(plotter: LivePlot, plot_batches: bool):
         plotter._liveplot = True
         plotter.max_fraction_spent_plotting = 1.0
         plotter.set_train_batch({}, batch_size=1, plot=plot_batches)
-        plotter.plot_train_epoch()
-        plotter.plot_test_epoch()
+        plotter.set_train_epoch()
+        plotter.set_test_epoch()
         for name, metric in plotter._train_metrics.items():
             if metric.batch_domain.size:
                 assert metric.batch_line is None or (
@@ -190,7 +190,7 @@ def test_plot_last_n_batches(
         for n, datum in enumerate(train_data):
             plotter.set_train_batch(dict(a=datum), batch_size=1, plot=True)
             if n + 1 in epochs:
-                plotter.plot_train_epoch()
+                plotter.set_train_epoch()
 
             # check batches
             actual_batchx = plotter._train_metrics["a"].batch_line.get_xdata()


### PR DESCRIPTION
Normalizes the interfaces of `noggin.logger.LiveLogger` and `noggin.plotter.LivePlot`
so that they can be used as drop-in replacements for each other more seamlessly.

This is an API-breaking update for `noggin.plotter.LivePlot`, as it renames the methods
``plot_train_epoch`` and ``plot_test_epoch`` to ``set_train_epoch`` and ``set_test_epoch``,
respectively. As stated above, this is to match the interface of  `noggin.logger.LiveLogger`.